### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,23 +1,26 @@
-Revision history for HTML-Mason-PSGIHandler
+Revision history for Perl module HTML::Mason::PSGIHandler
 
 {{$NEXT}}
 
-0.53  September 13, 2013
-  - Add new_psgi and as_psgi methods (Ricardo Signes)
-  - Fix memory leak (under certain conditions)
-  - basic test for leaks
-  - Slightly change the internal invoke_mason method for easier reuse
-    (Ask Bjørn Hansen)
+0.53 2013-09-13
+    - Add new_psgi and as_psgi methods (Ricardo Signes)
+    - Fix memory leak (under certain conditions)
+    - basic test for leaks
+    - Slightly change the internal invoke_mason method for easier reuse
+      (Ask Bjørn Hansen)
 
-0.52  October 22, 2010
-  - Add streaming handler, HTML::Mason::PSGIHandler::Streamy. (Chia-liang Kao)
+0.52 2010-10-22
+    - Add streaming handler, HTML::Mason::PSGIHandler::Streamy.
+      (Chia-liang Kao)
 
-0.51  October 18, 2010
-  - For body-less response, don't return an undef body element (Chia-liang Kao)
-  - Pass Mason -Status into psgi_header (Shawn M Moore)
+0.51 2010-10-18
+    - For body-less response, don't return an undef body element
+      (Chia-liang Kao)
+    - Pass Mason -Status into psgi_header (Shawn M Moore)
 
-0.50  September 12, 2010
-  - First CPAN release
+0.50 2010-09-12
+    - First CPAN release
 
-0.01  September 30, 2009
-  - Original version
+0.01 2009-09-30
+    - Original version
+

--- a/dist.ini
+++ b/dist.ini
@@ -36,7 +36,7 @@ bugtracker.web    = http://github.com/abh/HTML-Mason-PSGIHandler/issues
 [EOLTests]
 
 [NextRelease]
-format = %-5v %{MMMM d, yyyy}d
+format = %-5v %{yyyy-MM-dd}d
 
 [@Git]
 # push_to    = all


### PR DESCRIPTION
Hi Ruslan,

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec. This was mainly changing the format of dates, with some other minor tweaks.

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil

PS I'm doing this because I'm on a quest to help improve CPAN:

> http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086

You can check the status of your Changes files for all dists:

> http://changes.cpanhq.org/author/RUZ

If you choose you update the others, you can log them in comments on the quest :-)
